### PR TITLE
appinfo.json: Update requiredPermissions

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -8,5 +8,5 @@
 	"main": "index.html",
 	"icon": "icon.png",
 	"uiRevision": "2",
-	"requiredPermissions": ["database.internal"]
+	"requiredPermissions": ["database.operation"]
 }


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 2 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'database.internal' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   org.webosports.app.memos.app.json